### PR TITLE
No longer failing when using MediaInfo if the assembly was loaded from a byte stream.

### DIFF
--- a/MediaInfoDotNet/MediaInfoDLL.cs
+++ b/MediaInfoDotNet/MediaInfoDLL.cs
@@ -26,6 +26,7 @@
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Security;
@@ -201,9 +202,15 @@ namespace MediaInfoLib
                 if (moduleHandle == IntPtr.Zero)
                 {
                     string fullexepath = System.Reflection.Assembly.GetExecutingAssembly().Location;
-                    FileInfo fi = new FileInfo(fullexepath);
-                    fullexepath = Path.Combine(fi.Directory.FullName, Environment.Is64BitProcess ? "x64" : "x86", "MediaInfo.dll");
-                    moduleHandle = UnsafeNativeMethods.LoadLibraryEx(fullexepath, IntPtr.Zero, 0);
+                    if (fullexepath != String.Empty)
+                    {
+                        FileInfo fi = new FileInfo(fullexepath);
+                        fullexepath = Path.Combine(fi.Directory.FullName, Environment.Is64BitProcess ? "x64" : "x86", "MediaInfo.dll");
+                        moduleHandle = UnsafeNativeMethods.LoadLibraryEx(fullexepath, IntPtr.Zero, 0);
+                    }else
+                    {
+                        Trace.TraceWarning("MediaInfoDotNet could not automatically load MediaInfo.dll. You will need to manually load the file using using LoadLibraryEx() or ensuring that the file is in the default library search paths.");
+                    }
                 }
                 MustUseAnsi = true;
             }


### PR DESCRIPTION
Loading an assembly like this causes the Assembly.Location property to be an empty string since the assembly doesn't exist on disk, but instead in memory.