### PR TITLE
Changed duration from int to double to support decimals.

### DIFF
--- a/MediaInfoDotNet/Models/AudioStream.cs
+++ b/MediaInfoDotNet/Models/AudioStream.cs
@@ -125,7 +125,7 @@ namespace MediaInfoDotNet.Models
 
 		///<summary>Duration of the stream in milliseconds.</summary>
 		[Description("Duration of the stream in milliseconds."), Category("GeneralVideoAudioTextMenu")]
-		public int Duration { get { return this.duration; } }
+		public double Duration { get { return this.duration; } }
 
 		#endregion
 

--- a/MediaInfoDotNet/Models/BaseStreamCommons.cs
+++ b/MediaInfoDotNet/Models/BaseStreamCommons.cs
@@ -245,12 +245,12 @@ namespace MediaInfoDotNet.Models
 			}
 		}
 
-		int _duration = int.MinValue;
+		double _duration = double.MinValue;
 		///<summary>Duration of the stream in milliseconds.</summary>
-		public int duration {
+		public double duration {
 			get {
-				if (_duration == int.MinValue)
-					_duration = miGetInt("Duration");
+				if (_duration == double.MinValue)
+					_duration = miGetDouble("Duration");
 				return _duration;
 			}
 		}

--- a/MediaInfoDotNet/Models/GeneralStream.cs
+++ b/MediaInfoDotNet/Models/GeneralStream.cs
@@ -110,7 +110,7 @@ namespace MediaInfoDotNet.Models
 
 		///<summary>Duration of the stream in milliseconds.</summary>
 		[Description("Duration of the stream in milliseconds."), Category("GeneralVideoAudioTextMenu")]
-		public int Duration { get { return this.duration; } }
+		public double Duration { get { return this.duration; } }
 
 		#endregion
 

--- a/MediaInfoDotNet/Models/MenuStream.cs
+++ b/MediaInfoDotNet/Models/MenuStream.cs
@@ -91,7 +91,7 @@ namespace MediaInfoDotNet.Models
 
 		///<summary>Duration of the stream in milliseconds.</summary>
 		[Description("Duration of the stream in milliseconds."), Category("GeneralVideoAudioTextMenu")]
-		public int Duration { get { return this.duration; } }
+		public double Duration { get { return this.duration; } }
 
 		#endregion
 

--- a/MediaInfoDotNet/Models/TextStream.cs
+++ b/MediaInfoDotNet/Models/TextStream.cs
@@ -122,7 +122,7 @@ namespace MediaInfoDotNet.Models
 
 		///<summary>Duration of the stream in milliseconds.</summary>
 		[Description("Duration of the stream in milliseconds."), Category("GeneralVideoAudioTextMenu")]
-		public int Duration { get { return this.duration; } }
+		public double Duration { get { return this.duration; } }
 
 		#endregion
 

--- a/MediaInfoDotNet/Models/VideoStream.cs
+++ b/MediaInfoDotNet/Models/VideoStream.cs
@@ -125,7 +125,7 @@ namespace MediaInfoDotNet.Models
 
 		///<summary>Duration of the stream in milliseconds.</summary>
 		[Description("Duration of the stream in milliseconds."), Category("GeneralVideoAudioTextMenu")]
-		public int Duration { get { return this.duration; } }
+		public double Duration { get { return this.duration; } }
 
 		#endregion
 


### PR DESCRIPTION
I discovered several MKV files containing a duration that included decimals (when interpreted as milliseconds).
These files caused the library to choke upon failure of `int.TryParse()` in `Media.miGetInt()`.
Therefore, I changed all durations from `int` to `double`.